### PR TITLE
Use CSS syntax highlighting for CSS snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ module.exports = {
 
 ```
 8. Add TailwindCSS derictive files to style.css
-```js
+```css
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
This PR adds CSS syntax highlighting to the CSS snippets in the README.md file